### PR TITLE
fixes jquery hijacking problem

### DIFF
--- a/src/omnibar/omnibar-script-loader.spec.ts
+++ b/src/omnibar/omnibar-script-loader.spec.ts
@@ -43,4 +43,45 @@ describe('Omnibar script loader', () => {
       });
   });
 
+  it('should not register a script if a higher version is already registered', (done) => {
+    const appendChildSpy = spyOn(
+      document.body,
+      'appendChild'
+    )
+      .and.callFake((el: any) => {
+        el.onload();
+      });
+
+    BBOmnibarScriptLoader
+      .smartRegisterScript('http://example.com/', '2.3.4', '3.1.0')
+      .then(() => {
+        expect(appendChildSpy).not.toHaveBeenCalledWith(
+          jasmine.objectContaining({
+            src: 'https://example.com'
+          })
+        );
+        done();
+      });
+  });
+
+  it('should not register a script if the same version is already registered', (done) => {
+    const appendChildSpy = spyOn(
+      document.body,
+      'appendChild'
+    )
+      .and.callFake((el: any) => {
+        el.onload();
+      });
+
+    BBOmnibarScriptLoader
+      .smartRegisterScript('http://example.com/', '2.3.4', '2.3.4')
+      .then(() => {
+        expect(appendChildSpy).not.toHaveBeenCalledWith(
+          jasmine.objectContaining({
+            src: 'https://example.com'
+          })
+        );
+        done();
+      });
+  });
 });

--- a/src/omnibar/omnibar-script-loader.ts
+++ b/src/omnibar/omnibar-script-loader.ts
@@ -13,4 +13,39 @@ export class BBOmnibarScriptLoader {
     });
   }
 
+  public static smartRegisterScript(url: string, minVersion: string, currentVersion?: string): Promise<any> {
+      if (currentVersion && BBOmnibarScriptLoader.isVersionMet(minVersion, currentVersion)) {
+          return new Promise<any>((resolve: any, reject: any) => {
+              resolve();
+          });
+      }
+      return BBOmnibarScriptLoader.registerScript(url);
+  }
+
+  private static isVersionMet(min: string, cur: string): boolean {
+    let minVersion = BBOmnibarScriptLoader.parseVersionString(min);
+    let currentVersion = BBOmnibarScriptLoader.parseVersionString(cur);
+
+    for (let idx = 0; idx < minVersion.length; idx++) {
+      if (idx < currentVersion.length) {
+        if (currentVersion[idx] > minVersion[idx]) {
+          return true;
+        } else if (currentVersion[idx] < minVersion[idx]) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  private static parseVersionString(str: string): number[] {
+    let splitVersion = str.split('.');
+    let parsedVersion = [];
+
+    for (let num of splitVersion) {
+      let versionNum: number = parseInt(num, 10) || 0;
+      parsedVersion.push(versionNum);
+    }
+    return parsedVersion;
+  }
 }

--- a/src/omnibar/omnibar.spec.ts
+++ b/src/omnibar/omnibar.spec.ts
@@ -55,6 +55,66 @@ describe('Omnibar', () => {
     });
   });
 
+  it('should not register jQuery if a higher or equal version is already registered', (done) => {
+    // defining a jQuery verion
+    (<any> window).jQuery = {
+      fn: {
+          jquery: '3.2.1'
+        }
+    };
+
+    BBOmnibar.load({
+      serviceName: 'test'
+    }).then(() => {
+      expect(registerScriptSpy.calls.argsFor(0)).toEqual(
+        ['https://cdnjs.cloudflare.com/ajax/libs/easyXDM/2.4.17.1/easyXDM.min.js']
+      );
+
+      expect(registerScriptSpy.calls.argsFor(1)).toEqual(
+        ['https://signin.blackbaud.com/Omnibar.min.js']
+      );
+
+      done();
+    });
+  });
+
+  it('should add the required omnibar elements to the page', (done) => {
+    BBOmnibar.load({
+      serviceName: 'test'
+    }).then(() => {
+      expect(document.querySelectorAll('.bb-omnibar-height-padding')).not.toBeNull();
+
+      done();
+    });
+  });
+
+  it('should register jQuery if current version is less than the minimum version', (done) => {
+    // defining a jQuery version
+    (<any> window).jQuery = {
+      fn: {
+          jquery: '1.10.0'
+        }
+    };
+
+    BBOmnibar.load({
+      serviceName: 'test'
+    }).then(() => {
+      expect(registerScriptSpy.calls.argsFor(0)).toEqual(
+        ['https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.0/jquery.js']
+      );
+
+      expect(registerScriptSpy.calls.argsFor(1)).toEqual(
+        ['https://cdnjs.cloudflare.com/ajax/libs/easyXDM/2.4.17.1/easyXDM.min.js']
+      );
+
+      expect(registerScriptSpy.calls.argsFor(2)).toEqual(
+        ['https://signin.blackbaud.com/Omnibar.min.js']
+      );
+
+      done();
+    });
+  });
+
   it('should add the required omnibar elements to the page', (done) => {
     BBOmnibar.load({
       serviceName: 'test'

--- a/src/omnibar/omnibar.ts
+++ b/src/omnibar/omnibar.ts
@@ -10,8 +10,12 @@ export class BBOmnibar {
     }
 
     return new Promise<any>((resolve: any, reject: any) => {
-      BBOmnibarScriptLoader.registerScript(
-        'https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.0/jquery.js'
+      const jquery = (<any> window).jQuery;
+      const jqueryVersion = jquery && jquery.fn && jquery.fn.jquery;
+      BBOmnibarScriptLoader.smartRegisterScript(
+        'https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.0/jquery.js',
+        '2.1.0',
+        jqueryVersion
       )
         .then(() => {
           return BBOmnibarScriptLoader.registerScript(


### PR DESCRIPTION
These changes are to fix a problem that I ran into while trying to use auth-client on the Attentive.ly app. The jQuery library loaded asynchronously by auth-client was overwriting the jQuery library previously loaded by Attentive.ly, and thus breaking a lot of functionality. This pull request adds the ability to check for an existing version of jQuery that is >= to the version auth-client needs before actually loading it.