### PR TITLE
Update GetToken to work in IE

### DIFF
--- a/src/auth/auth-token-integration.ts
+++ b/src/auth/auth-token-integration.ts
@@ -67,6 +67,6 @@ export class BBAuthTokenIntegration {
 
     xhr.setRequestHeader('Accept', 'application/json');
     xhr.withCredentials = true;
-    xhr.send(undefined);
+    xhr.send();
   }
 }


### PR DESCRIPTION
When calling send with undefined, IE includes undefines in the post body
and the Auth service rejects the request.  Sending with no value
specified works across browsers.