### PR TITLE
Dont use CSRF on requesting a token

### DIFF
--- a/src/auth/auth-token-integration.spec.ts
+++ b/src/auth/auth-token-integration.spec.ts
@@ -15,7 +15,8 @@ describe('Auth token integration', () => {
       undefined,
       undefined,
       undefined,
-      undefined
+      undefined,
+      true
     );
 
     requestSpy.calls.reset();
@@ -27,7 +28,8 @@ describe('Auth token integration', () => {
       undefined,
       true,
       'abc',
-      '123'
+      '123',
+      true
     );
   });
 

--- a/src/auth/auth-token-integration.ts
+++ b/src/auth/auth-token-integration.ts
@@ -7,7 +7,8 @@ export class BBAuthTokenIntegration {
       undefined,
       disableRedirect,
       envId,
-      permissionScope
+      permissionScope,
+      true
     );
   }
 }

--- a/src/shared/csrf-xhr.spec.ts
+++ b/src/shared/csrf-xhr.spec.ts
@@ -137,6 +137,37 @@ describe('Auth token integration', () => {
     });
   });
 
+  it('should not call csrf endpoint if bypassCsrf is set', (done) => {
+    const tokenPromise = BBCsrfXhr.request(
+      'https://example.com/token',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true
+    );
+    const tokenRequest = jasmine.Ajax.requests.mostRecent();
+
+    if (tokenRequest.url === 'https://example.com/token') {
+      tokenRequest.respondWith({
+        responseText: JSON.stringify({
+          access_token: 'xyz',
+          expires_in: 12345
+        }),
+        status: 200
+      });
+
+      tokenPromise.then((tokenResponse: any) => {
+        expect(tokenResponse).toEqual({
+          access_token: 'xyz',
+          expires_in: 12345
+        });
+
+        done();
+      });
+    }
+  });
+
   it('should not try to parse an empty response', () => {
     BBCsrfXhr.request('https://example.com/token');
     const request = jasmine.Ajax.requests.mostRecent();

--- a/src/shared/csrf-xhr.spec.ts
+++ b/src/shared/csrf-xhr.spec.ts
@@ -147,10 +147,12 @@ describe('Auth token integration', () => {
       true
     );
 
-    setInterval(() => {
+    const intervalId = setInterval(() => {
       const tokenRequest = jasmine.Ajax.requests.mostRecent();
 
       if (tokenRequest.url === 'https://example.com/token') {
+        clearInterval(intervalId);
+
         tokenRequest.respondWith({
           responseText: JSON.stringify({
             access_token: 'xyz',

--- a/src/shared/csrf-xhr.spec.ts
+++ b/src/shared/csrf-xhr.spec.ts
@@ -146,26 +146,29 @@ describe('Auth token integration', () => {
       undefined,
       true
     );
-    const tokenRequest = jasmine.Ajax.requests.mostRecent();
 
-    if (tokenRequest.url === 'https://example.com/token') {
-      tokenRequest.respondWith({
-        responseText: JSON.stringify({
-          access_token: 'xyz',
-          expires_in: 12345
-        }),
-        status: 200
-      });
+    setTimeout(() => {
+      const tokenRequest = jasmine.Ajax.requests.mostRecent();
 
-      tokenPromise.then((tokenResponse: any) => {
-        expect(tokenResponse).toEqual({
-          access_token: 'xyz',
-          expires_in: 12345
+      if (tokenRequest.url === 'https://example.com/token') {
+        tokenRequest.respondWith({
+          responseText: JSON.stringify({
+            access_token: 'xyz',
+            expires_in: 12345
+          }),
+          status: 200
         });
 
-        done();
-      });
-    }
+        tokenPromise.then((tokenResponse: any) => {
+          expect(tokenResponse).toEqual({
+            access_token: 'xyz',
+            expires_in: 12345
+          });
+
+          done();
+        });
+      }
+    });
   });
 
   it('should not try to parse an empty response', () => {

--- a/src/shared/csrf-xhr.spec.ts
+++ b/src/shared/csrf-xhr.spec.ts
@@ -147,7 +147,7 @@ describe('Auth token integration', () => {
       true
     );
 
-    setTimeout(() => {
+    setInterval(() => {
       const tokenRequest = jasmine.Ajax.requests.mostRecent();
 
       if (tokenRequest.url === 'https://example.com/token') {

--- a/src/shared/csrf-xhr.ts
+++ b/src/shared/csrf-xhr.ts
@@ -123,7 +123,6 @@ export class BBCsrfXhr {
             csrf_token: 'token_needed'
           });
         } else {
-          console.log('CSRF NEEDED FOR: ' + url);
           requestToken(CSRF_URL, 'token_needed')
             .then(resolveCsrf)
             .catch(rejectCsrf);


### PR DESCRIPTION
What are your thoughts about this approach?  Several other calls are going through this that do need the extra CSRF hop.