### PR TITLE
Add missing  property to omnibar service item

### DIFF
--- a/src/omnibar/omnibar-service-item.ts
+++ b/src/omnibar/omnibar-service-item.ts
@@ -5,6 +5,8 @@ export interface BBOmnibarServiceItem {
 
   items?: BBOmnibarNavigationItem[];
 
+  selected?: boolean;
+
   specialItems?: BBOmnibarNavigationItem[];
 
   imageUrl?: string;


### PR DESCRIPTION
We're getting the following `at-loader` compiler error in Builder's internal unit tests:

```
ERROR in [at-loader] ./src/app/app.component.spec.ts:492:63 
TS2339: Property 'selected' does not exist on type 'BBOmnibarServiceItem'.
```

This property is set by Builder's `app.component.ts` file, here:
https://github.com/blackbaud/skyux-sdk-builder/blob/master/src/app/app.component.ts#L82

And Builder v.1, here:
https://github.com/blackbaud/skyux-builder/blob/master/src/app/app.component.ts#L72