### PR TITLE
Export 1bb-url-protocol helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ jspm_packages
 dist
 
 .DS_Store
+
+.idea/

--- a/src/auth/auth.spec.ts
+++ b/src/auth/auth.spec.ts
@@ -247,7 +247,7 @@ describe('Auth', () => {
     });
   });
 
-  it('should tokenized urls honoring the hard-coded zone, while ignoring any port protocol information', (done) => {
+  it('should tokenize urls honoring the hard-coded zone, while ignoring any port protocol information', (done) => {
     BBAuth.getUrl(
       '1bb://eng-hub00-pusa01:8080/version'
     ).then((url: string) => {
@@ -256,7 +256,7 @@ describe('Auth', () => {
     });
   });
 
-  it('should tokenized urls getting the zone from the token, while ignoring any port protocol information', (done) => {
+  it('should tokenize urls getting the zone from the token, while ignoring any port protocol information', (done) => {
     BBAuth.getUrl(
       '1bb://eng-hub00:8080/version',
       {

--- a/src/auth/auth.spec.ts
+++ b/src/auth/auth.spec.ts
@@ -246,4 +246,25 @@ describe('Auth', () => {
       done();
     });
   });
+
+  it('should tokenized urls honoring the hard-coded zone, while ignoring any port protocol information', (done) => {
+    BBAuth.getUrl(
+      '1bb://eng-hub00-pusa01:8080/version'
+    ).then((url: string) => {
+      expect(url).toBe('https://eng-pusa01.app.blackbaud.net/hub00/version');
+      done();
+    });
+  });
+
+  it('should tokenized urls getting the zone from the token, while ignoring any port protocol information', (done) => {
+    BBAuth.getUrl(
+      '1bb://eng-hub00:8080/version',
+      {
+        zone: 'p-can01'
+      }
+    ).then((url: string) => {
+      expect(url).toBe('https://eng-pcan01.app.blackbaud.net/hub00/version');
+      done();
+    });
+  });
 });

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -19,6 +19,10 @@ import {
 //#endregion
 
 const TOKENIZED_URL_REGEX = /1bb:\/\/([a-z]{3})-([a-z0-9]{5})(-[a-z]{4}[0-9]{2})?\/(.*)/;
+const SCS_INDEX = 1;
+const SERVICE_INDEX = 2;
+const ZONE_INDEX = 3;
+const ENDPOINT_INDEX = 4;
 
 function buildCacheKey(args: BBAuthGetTokenArgs) {
   const { envId, permissionScope, leId } = args;
@@ -57,11 +61,11 @@ export class BBAuth {
     }
 
     if (match) {
-      if (match[3]) {
-        zone = match[3].substring(1);
+      if (match[ZONE_INDEX]) {
+        zone = match[ZONE_INDEX].substring(1);
       }
       // https://eng-pusa01.app.blackbaud.net/hub00/version
-      result = `https://${match[1]}-${zone}.app.blackbaud.net/${match[2]}/${match[4]}`;
+      result = `https://${match[SCS_INDEX]}-${zone}.app.blackbaud.net/${match[SERVICE_INDEX]}/${match[ENDPOINT_INDEX]}`;
     }
     return Promise.resolve(result);
   }

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -18,11 +18,12 @@ import {
 
 //#endregion
 
-const TOKENIZED_URL_REGEX = /1bb:\/\/([a-z]{3})-([a-z0-9]{5})(-[a-z]{4}[0-9]{2})?\/(.*)/;
+const TOKENIZED_URL_REGEX = /1bb:\/\/([a-z]{3})-([a-z0-9]{5})(-[a-z]{4}[0-9]{2})?(:[0-9]+)?\/(.*)/;
 const SCS_INDEX = 1;
 const SERVICE_INDEX = 2;
 const ZONE_INDEX = 3;
-const ENDPOINT_INDEX = 4;
+// const PORT_INDEX = 4;
+const ENDPOINT_INDEX = 5;
 
 function buildCacheKey(args: BBAuthGetTokenArgs) {
   const { envId, permissionScope, leId } = args;

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -18,12 +18,12 @@ import {
 
 //#endregion
 
-const TOKENIZED_URL_REGEX = /1bb:\/\/([a-z]{3})-([a-z0-9]{5})(-[a-z]{4}[0-9]{2})?(:[0-9]+)?\/(.*)/;
-const SCS_INDEX = 1;
-const SERVICE_INDEX = 2;
-const ZONE_INDEX = 3;
-// const PORT_INDEX = 4;
-const ENDPOINT_INDEX = 5;
+export const TOKENIZED_URL_REGEX = /1bb:\/\/([a-z]{3})-([a-z0-9]{5})(-[a-z]{4}[0-9]{2})?(:[0-9]+)?\/(.*)/;
+export const SCS_INDEX = 1;
+export const SERVICE_INDEX = 2;
+export const ZONE_INDEX = 3;
+export const LOCAL_PORT_INDEX = 4;
+export const ENDPOINT_INDEX = 5;
 
 function buildCacheKey(args: BBAuthGetTokenArgs) {
   const { envId, permissionScope, leId } = args;


### PR DESCRIPTION
This is the bare minimum work @blackbaud-rachelbeale and I feel we'll need to do the locally served backend service checking.

We are not sure about this design as we do not like that we're exposing the implementation detail of using a regex matcher external to this library.  We've gone back and forth on creating a `1bb url protocol` parser/factory which will hide away the regexing of an input string, while still allowing a consumer to get information about the URL, the prod version of the URL, or a localhost version of the URL.