### PR TITLE
Added publishToNPM property

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/bundles/auth-client.umd.js",
   "module": "index.ts",
   "pipelineSettings": {
-    "publishToCDN": true
+    "publishToCDN": true,
+    "publishToNPM": true
   },
   "scripts": {
     "ci": "npm run test:ci && npm run build",


### PR DESCRIPTION
This is to support an upcoming pipeline change.

It does not require an npm publish.