### PR TITLE
`svcid` checks for enabling notifications

### DIFF
--- a/src/omnibar/omnibar.spec.ts
+++ b/src/omnibar/omnibar.spec.ts
@@ -1351,7 +1351,8 @@ describe('Omnibar', () => {
         await testSvcId('fenxt', true, true);
         await testSvcId('skydev', false, true);
         await testSvcId('skydevhome', false, true);
-        await testSvcId('skyux', false, false);
+        await testSvcId('skyux', false, true);
+        await testSvcId('other', false, false);
       });
 
     });

--- a/src/omnibar/omnibar.spec.ts
+++ b/src/omnibar/omnibar.spec.ts
@@ -1294,67 +1294,63 @@ describe('Omnibar', () => {
       });
     });
 
-    describe('handle notifications per svcid', () => {
+    describe('when connecting to notifications', () => {
 
       function testSvcId(
         svcId: string,
         tokenSpyCalled: boolean,
-        notificationsInitialized: boolean,
-        done: DoneFn
-      ): void {
-        startTrackingSpy.and.callFake((refreshUserCallback: () => void) => {
-          refreshUserCallback();
+        notificationsInitialized: boolean
+      ): Promise<void> {
+        return new Promise((resolve) => {
+          startTrackingSpy.and.callFake((refreshUserCallback: () => void) => {
+            refreshUserCallback();
 
-          setTimeout(() => {
-            let allArgsExpectation = expect(getTokenSpy.calls.allArgs());
-            if (!tokenSpyCalled) {
-              allArgsExpectation = allArgsExpectation.not;
-            }
-            allArgsExpectation.toContain(
-              [{
-                disableRedirect: true,
-                envId: 'envid',
-                leId: 'leid',
-                permissionScope: 'Notifications'
-              }]
-            );
+            setTimeout(() => {
+              let allArgsExpectation = expect(getTokenSpy.calls.allArgs());
+              if (!tokenSpyCalled) {
+                allArgsExpectation = allArgsExpectation.not;
+              }
+              allArgsExpectation.toContain(
+                [{
+                  disableRedirect: true,
+                  envId: 'envid',
+                  leId: 'leid',
+                  permissionScope: 'Notifications'
+                }]
+              );
 
-            let toastContainerExpectation = expect(toastContainerInitSpy);
-            if (!notificationsInitialized) {
-              toastContainerExpectation = toastContainerExpectation.not;
-            }
-            toastContainerExpectation.toHaveBeenCalled();
+              let toastContainerExpectation = expect(toastContainerInitSpy);
+              if (!notificationsInitialized) {
+                toastContainerExpectation = toastContainerExpectation.not;
+              }
+              toastContainerExpectation.toHaveBeenCalled();
 
-            done();
+              getTokenSpy.calls.reset();
+              toastContainerInitSpy.calls.reset();
+              destroyOmnibar();
+
+              resolve();
+            });
           });
-        });
 
-        loadOmnibar({
-          envId: 'envid',
-          leId: 'leid',
-          svcId
-        });
+          loadOmnibar({
+            envId: 'envid',
+            leId: 'leid',
+            svcId
+          });
 
-        fireMessageEvent({
-          messageType: 'get-token',
-          tokenRequestId: 123
+          fireMessageEvent({
+            messageType: 'get-token',
+            tokenRequestId: 123
+          });
         });
       }
 
-      it('renxt', (done) => {
-        testSvcId('renxt', true, true, done);
-      });
-
-      it('fenxt', (done) => {
-        testSvcId('fenxt', true, true, done);
-      });
-
-      it('skydev', (done) => {
-        testSvcId('skydev', false, true, done);
-      });
-
-      it('skyux', (done) => {
-        testSvcId('skyux', false, false, done);
+      it('should respect the notification settings for a given service ID', async () => {
+        await testSvcId('renxt', true, true);
+        await testSvcId('fenxt', true, true);
+        await testSvcId('skydev', false, true);
+        await testSvcId('skyux', false, false);
       });
 
     });

--- a/src/omnibar/omnibar.spec.ts
+++ b/src/omnibar/omnibar.spec.ts
@@ -1,5 +1,3 @@
-//#region imports
-
 import {
   BBOmnibar
 } from './omnibar';
@@ -63,8 +61,6 @@ import {
 import {
   BBOmnibarToastContainerInitArgs
 } from './omnibar-toast-container-init-args';
-
-//#endregion
 
 describe('Omnibar', () => {
   const BASE_URL = 'about:blank';
@@ -1310,19 +1306,32 @@ describe('Omnibar', () => {
           refreshUserCallback();
 
           setTimeout(() => {
-            expect(getTokenSpy).toHaveBeenCalledTimes(tokenSpyCalled ? 3 : 2);
-
-            if (notificationsInitialized) {
-              expect(toastContainerInitSpy).toHaveBeenCalled();
-            } else {
-              expect(toastContainerInitSpy).not.toHaveBeenCalled();
+            let allArgsExpectation = expect(getTokenSpy.calls.allArgs());
+            if (!tokenSpyCalled) {
+              allArgsExpectation = allArgsExpectation.not;
             }
+            allArgsExpectation.toContain(
+              [{
+                disableRedirect: true,
+                envId: 'envid',
+                leId: 'leid',
+                permissionScope: 'Notifications'
+              }]
+            );
+
+            let toastContainerExpectation = expect(toastContainerInitSpy);
+            if (!notificationsInitialized) {
+              toastContainerExpectation = toastContainerExpectation.not;
+            }
+            toastContainerExpectation.toHaveBeenCalled();
 
             done();
           });
         });
 
         loadOmnibar({
+          envId: 'envid',
+          leId: 'leid',
           svcId
         });
 

--- a/src/omnibar/omnibar.spec.ts
+++ b/src/omnibar/omnibar.spec.ts
@@ -1391,7 +1391,7 @@ describe('Omnibar', () => {
     });
 
     it('should return false if retrieving a token fails', (done) => {
-      loadOmnibar();
+      loadOmnibarWithNotifications();
 
       getTokenFake = () => Promise.reject('The user is not logged in');
 

--- a/src/omnibar/omnibar.spec.ts
+++ b/src/omnibar/omnibar.spec.ts
@@ -1350,6 +1350,7 @@ describe('Omnibar', () => {
         await testSvcId('renxt', true, true);
         await testSvcId('fenxt', true, true);
         await testSvcId('skydev', false, true);
+        await testSvcId('skydevhome', false, true);
         await testSvcId('skyux', false, false);
       });
 

--- a/src/omnibar/omnibar.ts
+++ b/src/omnibar/omnibar.ts
@@ -660,9 +660,9 @@ export class BBOmnibar {
 
             return false;
           }
-          ).catch(() => {
-            return false;
-          });
+        ).catch(() => {
+          return false;
+        });
       } else {
         return Promise.resolve(true);
       }

--- a/src/omnibar/omnibar.ts
+++ b/src/omnibar/omnibar.ts
@@ -76,6 +76,9 @@ const notificationSvcIds: {
   },
   skydev: {
     requiresNotif: false
+  },
+  skydevhome: {
+    requiresNotif: false
   }
 };
 

--- a/src/omnibar/omnibar.ts
+++ b/src/omnibar/omnibar.ts
@@ -79,6 +79,9 @@ const notificationSvcIds: {
   },
   skydevhome: {
     requiresNotif: false
+  },
+  skyux: {
+    requiresNotif: false
   }
 };
 

--- a/src/omnibar/omnibar.ts
+++ b/src/omnibar/omnibar.ts
@@ -63,7 +63,11 @@ import {
 const CLS_EXPANDED = 'sky-omnibar-iframe-expanded';
 const CLS_LOADING = 'sky-omnibar-loading';
 
-const notificationSvcIds: any = {
+const notificationSvcIds: {
+  [key: string]: {
+    requiresNotif: boolean
+  }
+} = {
   fenxt: {
     requiresNotif: true
   },


### PR DESCRIPTION
Logic:
Showing the bell in the the LE/ENV context:
If the org has `notif` AND (`renxt` or `fenxt`) » show the bell

Showing the bell when there is no LE context:
If `svcid` == `skydev` » show the bell