### PR TITLE
Highlight `Test` and `Sandbox` environments differently

### DIFF
--- a/src/omnibar/omnibar.spec.ts
+++ b/src/omnibar/omnibar.spec.ts
@@ -580,7 +580,7 @@ describe('Omnibar', () => {
 
       const environmentEl = document.querySelector('.sky-omnibar-environment') as any;
       const environmentNameEl = document.querySelector('.sky-omnibar-environment-name') as any;
-      const environmentInfoEl = document.querySelector('.sky-omnibar-environment-info') as any;
+      const environmentInfoEl = document.querySelector('.sky-omnibar-environment-description') as any;
       let environmentInfoLinkEl: any;
 
       const validateVisible = (visible: boolean) => {
@@ -589,8 +589,8 @@ describe('Omnibar', () => {
         expect(environmentNameEl.innerText.trim()).toBe(visible ? 'Environment name' : '');
       };
 
-      const validateAdditionalInfo = (visible: boolean, url?: boolean) => {
-        expect(environmentEl.classList.contains('sky-omnibar-environment-additional-info')).toBe(visible);
+      const validateDescription = (visible: boolean, url?: boolean) => {
+        expect(environmentEl.classList.contains('sky-omnibar-environment-description-present')).toBe(visible);
 
         environmentInfoLinkEl = environmentInfoEl.querySelector('a');
 
@@ -604,7 +604,7 @@ describe('Omnibar', () => {
       };
 
       validateVisible(false);
-      validateAdditionalInfo(false);
+      validateDescription(false);
 
       fireMessageEvent({
         messageType: 'environment-update',
@@ -612,7 +612,7 @@ describe('Omnibar', () => {
       });
 
       validateVisible(true);
-      validateAdditionalInfo(false);
+      validateDescription(false);
 
       fireMessageEvent({
         messageType: 'environment-update',
@@ -620,26 +620,26 @@ describe('Omnibar', () => {
       });
 
       validateVisible(false);
-      validateAdditionalInfo(false);
+      validateDescription(false);
 
       fireMessageEvent({
-        additionalInfo: 'Test environment',
+        description: 'Test environment',
         messageType: 'environment-update',
         name: 'Environment name'
       });
 
       validateVisible(true);
-      validateAdditionalInfo(true);
+      validateDescription(true);
 
       fireMessageEvent({
-        additionalInfo: 'Test environment',
+        description: 'Test environment',
         messageType: 'environment-update',
         name: 'Environment name',
         url: 'https://app.blackbaud.com/auth-client-env-url'
       });
 
       validateVisible(true);
-      validateAdditionalInfo(true, true);
+      validateDescription(true, true);
     });
 
     it('should restart activity tracking when the legacy session keep-alive URL changes', () => {

--- a/src/omnibar/omnibar.spec.ts
+++ b/src/omnibar/omnibar.spec.ts
@@ -558,14 +558,32 @@ describe('Omnibar', () => {
       loadOmnibar();
 
       const environmentEl = document.querySelector('.sky-omnibar-environment') as any;
+      const environmentNameEl = document.querySelector('.sky-omnibar-environment-name') as any;
+      const environmentInfoEl = document.querySelector('.sky-omnibar-environment-info') as any;
+      let environmentInfoLinkEl: any;
 
       const validateVisible = (visible: boolean) => {
         expect(document.body.classList.contains('sky-omnibar-environment-visible')).toBe(visible);
         expect(getComputedStyle(environmentEl).height).toBe(visible ? '24px' : '0px');
-        expect(environmentEl.innerText.trim()).toBe(visible ? 'Environment name' : '');
+        expect(environmentNameEl.innerText.trim()).toBe(visible ? 'Environment name' : '');
+      };
+
+      const validateAdditionalInfo = (visible: boolean, url?: boolean) => {
+        expect(environmentEl.classList.contains('sky-omnibar-environment-additional-info')).toBe(visible);
+
+        environmentInfoLinkEl = environmentInfoEl.querySelector('a');
+
+        if (visible && url) {
+          expect(environmentInfoLinkEl.innerText.trim()).toBe('Test environment');
+          expect(environmentInfoLinkEl.href).toBe('https://app.blackbaud.com/auth-client-env-url');
+        } else {
+          expect(environmentInfoLinkEl).toBe(null);
+          expect(environmentInfoEl.innerText.trim()).toBe(visible ? 'Test environment' : '');
+        }
       };
 
       validateVisible(false);
+      validateAdditionalInfo(false);
 
       fireMessageEvent({
         messageType: 'environment-update',
@@ -573,6 +591,7 @@ describe('Omnibar', () => {
       });
 
       validateVisible(true);
+      validateAdditionalInfo(false);
 
       fireMessageEvent({
         messageType: 'environment-update',
@@ -580,6 +599,26 @@ describe('Omnibar', () => {
       });
 
       validateVisible(false);
+      validateAdditionalInfo(false);
+
+      fireMessageEvent({
+        additionalInfo: 'Test environment',
+        messageType: 'environment-update',
+        name: 'Environment name'
+      });
+
+      validateVisible(true);
+      validateAdditionalInfo(true);
+
+      fireMessageEvent({
+        additionalInfo: 'Test environment',
+        messageType: 'environment-update',
+        name: 'Environment name',
+        url: 'https://app.blackbaud.com/auth-client-env-url'
+      });
+
+      validateVisible(true);
+      validateAdditionalInfo(true, true);
     });
 
     it('should restart activity tracking when the legacy session keep-alive URL changes', () => {

--- a/src/omnibar/omnibar.ts
+++ b/src/omnibar/omnibar.ts
@@ -438,48 +438,51 @@ function handlePushNotificationsChange(notifications: any[]): void {
   BBOmnibarPushNotifications.updateNotifications(notifications);
 }
 
-function handleEnvironmentUpdate(name: string, isSandbox: boolean, isTest: boolean, managementUrl: string) {
+function handleEnvironmentUpdate(
+  name: string,
+  isSandbox: boolean,
+  isTest: boolean,
+  managementUrl: string,
+  envInfo: string
+): void {
   const bodyCls = 'sky-omnibar-environment-visible';
-  const bodyClassList = document.body.classList;
   const sandboxCls = 'sky-omnibar-environment-sandbox';
-  const testCls = 'sky-omnibar-environment-test';
+  const testCls = 'sky-omnibar-environment-test';  
+  const bodyClassList = document.body.classList;
+
+  let addClass: string;
 
   name = name || '';
 
   envNameEl.innerText = name;
 
-  if (isSandbox) {
-    envEl.classList.add(sandboxCls);
-
-    if (managementUrl) {
-      const a = document.createElement('a');
-      a.href = managementUrl;
-      a.innerText = 'Sandbox environment';
-      envInfoEl.appendChild(a);
-    } else {
-      envInfoEl.innerText = 'Sandbox environment';
-    }
-  } else {
-    envEl.classList.remove(sandboxCls);
-  }
-  
-  if (isTest) {
-    envEl.classList.add(testCls);
-
-    if (managementUrl) {
-      const a = document.createElement('a');
-      a.href = managementUrl;
-      a.innerText = 'Test environment';
-      envInfoEl.appendChild(a);
-    } else {
-      envInfoEl.innerText = 'Test environment';
-    }
-  } else {
-    envEl.classList.remove(testCls);
-  }
-
   if (name) {
     bodyClassList.add(bodyCls);
+
+    if (isSandbox) {
+      addClass = sandboxCls;
+    } else {
+      envEl.classList.remove(sandboxCls);
+    }
+    
+    if (isTest) {
+      addClass = testCls;
+    } else {
+      envEl.classList.remove(testCls);
+    }
+
+    if (addClass) {
+      envEl.classList.add(addClass);
+
+      if (managementUrl) {
+        const a = document.createElement('a');
+        a.href = managementUrl;
+        a.innerText = envInfo;
+        envInfoEl.appendChild(a);
+      } else {
+        envInfoEl.innerText = envInfo;
+      }
+    }
   } else {
     bodyClassList.remove(bodyCls);
   }
@@ -629,7 +632,7 @@ function messageHandler(event: MessageEvent): void {
       BBOmnibarUserActivity.userRenewedSession();
       break;
     case 'environment-update':
-      handleEnvironmentUpdate(message.name, message.isSandbox, message.isTest, message.managementUrl);
+      handleEnvironmentUpdate(message.name, message.isSandbox, message.isTest, message.managementUrl, message.envInfo);
       break;
     case 'legacy-keep-alive-url-change':
       currentLegacyKeepAliveUrl = message.url;

--- a/src/omnibar/omnibar.ts
+++ b/src/omnibar/omnibar.ts
@@ -214,12 +214,9 @@ body {
   float: right;
 }
 
-.sky-omnibar-environment-sandbox {
-  background-color: #b7da9b;
-}
-
-.sky-omnibar-environment-test {
+.sky-omnibar-environment-additional-info {
   background-color: #ffeccf;
+  border-bottom: 2px solid #fbb034
 }
 
 .sky-omnibar-environment-visible .sky-omnibar-environment {
@@ -440,17 +437,12 @@ function handlePushNotificationsChange(notifications: any[]): void {
 
 function handleEnvironmentUpdate(
   name: string,
-  isSandbox: boolean,
-  isTest: boolean,
-  managementUrl: string,
-  envInfo: string
+  additionalInfo: string,
+  url: string,
 ): void {
   const bodyCls = 'sky-omnibar-environment-visible';
-  const sandboxCls = 'sky-omnibar-environment-sandbox';
-  const testCls = 'sky-omnibar-environment-test';  
+  const addInfoCls = 'sky-omnibar-environment-additional-info';
   const bodyClassList = document.body.classList;
-
-  let addClass: string;
 
   name = name || '';
 
@@ -459,29 +451,19 @@ function handleEnvironmentUpdate(
   if (name) {
     bodyClassList.add(bodyCls);
 
-    if (isSandbox) {
-      addClass = sandboxCls;
-    } else {
-      envEl.classList.remove(sandboxCls);
-    }
-    
-    if (isTest) {
-      addClass = testCls;
-    } else {
-      envEl.classList.remove(testCls);
-    }
+    if (additionalInfo) {
+      envEl.classList.add(addInfoCls);
 
-    if (addClass) {
-      envEl.classList.add(addClass);
-
-      if (managementUrl) {
+      if (url) {
         const a = document.createElement('a');
-        a.href = managementUrl;
-        a.innerText = envInfo;
+        a.href = url;
+        a.innerText = additionalInfo;
         envInfoEl.appendChild(a);
       } else {
-        envInfoEl.innerText = envInfo;
-      }
+        envInfoEl.innerText = additionalInfo;
+      }      
+    } else {
+      envEl.classList.remove(addInfoCls);
     }
   } else {
     bodyClassList.remove(bodyCls);
@@ -632,7 +614,7 @@ function messageHandler(event: MessageEvent): void {
       BBOmnibarUserActivity.userRenewedSession();
       break;
     case 'environment-update':
-      handleEnvironmentUpdate(message.name, message.isSandbox, message.isTest, message.managementUrl, message.envInfo);
+      handleEnvironmentUpdate(message.name, message.additionalInfo, message.url);
       break;
     case 'legacy-keep-alive-url-change':
       currentLegacyKeepAliveUrl = message.url;

--- a/src/omnibar/omnibar.ts
+++ b/src/omnibar/omnibar.ts
@@ -86,8 +86,8 @@ const notificationSvcIds: {
 };
 
 let envEl: HTMLDivElement;
-let envNameEl: HTMLDivElement;
-let envInfoEl: HTMLDivElement;
+let envNameEl: HTMLSpanElement;
+let envDescEl: HTMLSpanElement;
 let placeholderEl: HTMLDivElement;
 let styleEl: HTMLStyleElement;
 let iframeEl: HTMLIFrameElement;
@@ -111,13 +111,13 @@ function addEnvironmentEl(): void {
   envEl = document.createElement('div');
   envEl.className = 'sky-omnibar-environment';
 
-  envInfoEl = document.createElement('div');
-  envInfoEl.className = 'sky-omnibar-environment-info';
-  envEl.appendChild(envInfoEl);
-
-  envNameEl = document.createElement('div');
+  envNameEl = document.createElement('span');
   envNameEl.className = 'sky-omnibar-environment-name';
   envEl.appendChild(envNameEl);
+
+  envDescEl = document.createElement('span');
+  envDescEl.className = 'sky-omnibar-environment-description';
+  envEl.appendChild(envDescEl);
 
   BBAuthDomUtility.addElToBodyTop(envEl);
 }
@@ -208,22 +208,17 @@ body {
   line-height: 24px;
   overflow: hidden;
   padding: 0 15px;
-  position: relative;
+  text-align: right;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.sky-omnibar-environment-info {
-  float: right;
-  padding-left: 15px;
+.sky-omnibar-environment-description {
+  margin-left: 15px;
   font-weight: bold;
 }
 
-.sky-omnibar-environment-name {
-  float: right;
-}
-
-.sky-omnibar-environment-additional-info {
+.sky-omnibar-environment-description-present {
   background-color: #ffeccf;
   border-bottom: 2px solid #fbb034
 }
@@ -446,11 +441,11 @@ function handlePushNotificationsChange(notifications: any[]): void {
 
 function handleEnvironmentUpdate(
   name: string,
-  additionalInfo: string,
+  description: string,
   url: string
 ): void {
   const bodyCls = 'sky-omnibar-environment-visible';
-  const addInfoCls = 'sky-omnibar-environment-additional-info';
+  const descCls = 'sky-omnibar-environment-description-present';
   const bodyClassList = document.body.classList;
 
   name = name || '';
@@ -460,19 +455,19 @@ function handleEnvironmentUpdate(
   if (name) {
     bodyClassList.add(bodyCls);
 
-    if (additionalInfo) {
-      envEl.classList.add(addInfoCls);
+    if (description) {
+      envEl.classList.add(descCls);
 
       if (url) {
         const a = document.createElement('a');
         a.href = url;
-        a.innerText = additionalInfo;
-        envInfoEl.appendChild(a);
+        a.innerText = description;
+        envDescEl.appendChild(a);
       } else {
-        envInfoEl.innerText = additionalInfo;
+        envDescEl.innerText = description;
       }
     } else {
-      envEl.classList.remove(addInfoCls);
+      envEl.classList.remove(descCls);
     }
   } else {
     bodyClassList.remove(bodyCls);
@@ -623,7 +618,7 @@ function messageHandler(event: MessageEvent): void {
       BBOmnibarUserActivity.userRenewedSession();
       break;
     case 'environment-update':
-      handleEnvironmentUpdate(message.name, message.additionalInfo, message.url);
+      handleEnvironmentUpdate(message.name, message.description, message.url);
       break;
     case 'legacy-keep-alive-url-change':
       currentLegacyKeepAliveUrl = message.url;
@@ -752,7 +747,7 @@ export class BBOmnibar {
       placeholderEl =
       iframeEl =
       envEl =
-      envInfoEl =
+      envDescEl =
       envNameEl =
       promiseResolve =
       pushNotificationsConnected =

--- a/src/omnibar/omnibar.ts
+++ b/src/omnibar/omnibar.ts
@@ -438,7 +438,7 @@ function handlePushNotificationsChange(notifications: any[]): void {
 function handleEnvironmentUpdate(
   name: string,
   additionalInfo: string,
-  url: string,
+  url: string
 ): void {
   const bodyCls = 'sky-omnibar-environment-visible';
   const addInfoCls = 'sky-omnibar-environment-additional-info';
@@ -461,7 +461,7 @@ function handleEnvironmentUpdate(
         envInfoEl.appendChild(a);
       } else {
         envInfoEl.innerText = additionalInfo;
-      }      
+      }
     } else {
       envEl.classList.remove(addInfoCls);
     }

--- a/src/omnibar/omnibar.ts
+++ b/src/omnibar/omnibar.ts
@@ -205,17 +205,21 @@ body {
 }
 
 .sky-omnibar-environment-info {
-  text-align: center;
+  float: right;
+  padding-left: 15px;
+  font-weight: bold;
 }
 
 .sky-omnibar-environment-name {
-  position: absolute;
-  right: 15px;
-  top: 0;
+  float: right;
 }
 
 .sky-omnibar-environment-sandbox {
-  background-color: #b7da9b
+  background-color: #b7da9b;
+}
+
+.sky-omnibar-environment-test {
+  background-color: #ffeccf;
 }
 
 .sky-omnibar-environment-visible .sky-omnibar-environment {
@@ -438,6 +442,7 @@ function handleEnvironmentUpdate(name: string, isSandbox: boolean, isTest: boole
   const bodyCls = 'sky-omnibar-environment-visible';
   const bodyClassList = document.body.classList;
   const sandboxCls = 'sky-omnibar-environment-sandbox';
+  const testCls = 'sky-omnibar-environment-test';
 
   name = name || '';
 
@@ -445,16 +450,32 @@ function handleEnvironmentUpdate(name: string, isSandbox: boolean, isTest: boole
 
   if (isSandbox) {
     envEl.classList.add(sandboxCls);
-    envInfoEl.innerText = 'Sandbox';
 
     if (managementUrl) {
       const a = document.createElement('a');
       a.href = managementUrl;
-      a.innerText = "Manage environments";
+      a.innerText = 'Sandbox environment';
       envInfoEl.appendChild(a);
+    } else {
+      envInfoEl.innerText = 'Sandbox environment';
     }
   } else {
     envEl.classList.remove(sandboxCls);
+  }
+  
+  if (isTest) {
+    envEl.classList.add(testCls);
+
+    if (managementUrl) {
+      const a = document.createElement('a');
+      a.href = managementUrl;
+      a.innerText = 'Test environment';
+      envInfoEl.appendChild(a);
+    } else {
+      envInfoEl.innerText = 'Test environment';
+    }
+  } else {
+    envEl.classList.remove(testCls);
   }
 
   if (name) {

--- a/src/omnibar/omnibar.ts
+++ b/src/omnibar/omnibar.ts
@@ -68,6 +68,8 @@ const CLS_EXPANDED = 'sky-omnibar-iframe-expanded';
 const CLS_LOADING = 'sky-omnibar-loading';
 
 let envEl: HTMLDivElement;
+let envNameEl: HTMLDivElement;
+let envInfoEl: HTMLDivElement;
 let placeholderEl: HTMLDivElement;
 let styleEl: HTMLStyleElement;
 let iframeEl: HTMLIFrameElement;
@@ -90,6 +92,14 @@ function addIframeEl(): void {
 function addEnvironmentEl(): void {
   envEl = document.createElement('div');
   envEl.className = 'sky-omnibar-environment';
+
+  envInfoEl = document.createElement('div');
+  envInfoEl.className = 'sky-omnibar-environment-info';
+  envEl.appendChild(envInfoEl);
+
+  envNameEl = document.createElement('div');
+  envNameEl.className = 'sky-omnibar-environment-name';
+  envEl.appendChild(envNameEl);
 
   BBAuthDomUtility.addElToBodyTop(envEl);
 }
@@ -171,9 +181,23 @@ body {
   line-height: 24px;
   overflow: hidden;
   padding: 0 15px;
-  text-align: right;
+  position: relative;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.sky-omnibar-environment-info {
+  text-align: center;
+}
+
+.sky-omnibar-environment-name {
+  position: absolute;
+  right: 15px;
+  top: 0;
+}
+
+.sky-omnibar-environment-sandbox {
+  background-color: #b7da9b
 }
 
 .sky-omnibar-environment-visible .sky-omnibar-environment {
@@ -392,13 +416,28 @@ function handlePushNotificationsChange(notifications: any[]): void {
   BBOmnibarPushNotifications.updateNotifications(notifications);
 }
 
-function handleEnvironmentUpdate(name: string) {
+function handleEnvironmentUpdate(name: string, isSandbox: boolean, isTest: boolean, managementUrl: string) {
   const bodyCls = 'sky-omnibar-environment-visible';
   const bodyClassList = document.body.classList;
+  const sandboxCls = 'sky-omnibar-environment-sandbox';
 
   name = name || '';
 
-  envEl.innerText = name;
+  envNameEl.innerText = name;
+
+  if (isSandbox) {
+    envEl.classList.add(sandboxCls);
+    envInfoEl.innerText = 'Sandbox';
+
+    if (managementUrl) {
+      const a = document.createElement('a');
+      a.href = managementUrl;
+      a.innerText = "Manage environments";
+      envInfoEl.appendChild(a);
+    }
+  } else {
+    envEl.classList.remove(sandboxCls);
+  }
 
   if (name) {
     bodyClassList.add(bodyCls);
@@ -551,7 +590,7 @@ function messageHandler(event: MessageEvent): void {
       BBOmnibarUserActivity.userRenewedSession();
       break;
     case 'environment-update':
-      handleEnvironmentUpdate(message.name);
+      handleEnvironmentUpdate(message.name, message.isSandbox, message.isTest, message.managementUrl);
       break;
     case 'legacy-keep-alive-url-change':
       currentLegacyKeepAliveUrl = message.url;
@@ -672,6 +711,8 @@ export class BBOmnibar {
       placeholderEl =
       iframeEl =
       envEl =
+      envInfoEl =
+      envNameEl =
       promiseResolve =
       pushNotificationsConnected =
       unreadNotificationCount =


### PR DESCRIPTION
When a user is in an environment that is marked as either `Test` or `Sandbox`, highlight the environment bar in a style default then just the gray color.

Addresses #143